### PR TITLE
feat: add space management APIs

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,3 +67,25 @@ model PasswordResetToken {
 
   user User @relation(fields: [userId], references: [id])
 }
+
+model Space {
+  id        String   @id @default(uuid()) @db.Uuid
+  slug      String   @unique @db.VarChar(255)
+  name      String   @db.VarChar(255)
+  ownerId   String   @db.Uuid
+
+  owner     User      @relation(fields: [ownerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  logo      SpaceLogo?
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+}
+
+model SpaceLogo {
+  id          String  @id @default(uuid()) @db.Uuid
+  spaceId     String  @unique @db.Uuid
+  data        Bytes?
+  contentType String? @db.VarChar(255)
+  hash        String? @db.VarChar(64)
+
+  space Space @relation(fields: [spaceId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { AuthModule } from './auth/auth.module';
+import { SpaceModule } from './space/space.module';
 
 @Module({
-  imports: [ConfigModule.forRoot({ isGlobal: true }), AuthModule],
+  imports: [ConfigModule.forRoot({ isGlobal: true }), AuthModule, SpaceModule],
   controllers: [],
   providers: [],
 })

--- a/src/space/dto/create-space.dto.ts
+++ b/src/space/dto/create-space.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, Matches, MaxLength } from 'class-validator';
+
+export const SPACE_SLUG_REGEX = /^[a-z0-9]+(?:-[a-z0-9]+)*$/i;
+
+export class CreateSpaceDto {
+  @ApiProperty({
+    description:
+      'Human-friendly name that will be shown to members and guests.',
+    example: 'Product Team',
+    maxLength: 255,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(255)
+  name!: string;
+
+  @ApiProperty({
+    description: 'URL-safe slug used to identify the space in routes.',
+    example: 'product-team',
+    maxLength: 255,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(255)
+  @Matches(SPACE_SLUG_REGEX, {
+    message:
+      'Slug may only include alphanumeric characters and single hyphens separating segments.',
+  })
+  slug!: string;
+}

--- a/src/space/dto/space-response.dto.ts
+++ b/src/space/dto/space-response.dto.ts
@@ -1,0 +1,74 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class SpaceLogoResponseDto {
+  constructor(partial: Partial<SpaceLogoResponseDto> = {}) {
+    Object.assign(this, partial);
+  }
+
+  @ApiProperty({
+    description: 'MIME type of the stored logo image.',
+    example: 'image/png',
+    nullable: true,
+  })
+  contentType: string | null = null;
+
+  @ApiProperty({
+    description:
+      'SHA-256 hash of the stored logo data, useful for cache validation.',
+    example: '3d2e6c9a4cbb4a2e83b8f19e2ea1e148aef3791cbdc02fc7727f1b95ef5c1f0a',
+    nullable: true,
+  })
+  hash: string | null = null;
+}
+
+export class SpaceResponseDto {
+  constructor(partial: Partial<SpaceResponseDto> = {}) {
+    Object.assign(this, partial);
+  }
+
+  @ApiProperty({
+    description: 'Unique identifier of the space.',
+    example: 'ddeb27fb-d9a0-4624-be4d-4615062daed4',
+  })
+  id!: string;
+
+  @ApiProperty({
+    description: 'Slug used in URLs to reference the space.',
+    example: 'product-team',
+  })
+  slug!: string;
+
+  @ApiProperty({
+    description: 'Display name of the space.',
+    example: 'Product Team',
+  })
+  name!: string;
+
+  @ApiProperty({
+    description: 'Identifier of the user that owns the space.',
+    example: '0e3f5fbf-3a9e-4f1f-b7d6-9b9ec16d7056',
+  })
+  ownerId!: string;
+
+  @ApiProperty({
+    description: 'Timestamp when the space was first created.',
+    type: String,
+    format: 'date-time',
+  })
+  createdAt!: Date;
+
+  @ApiProperty({
+    description: 'Timestamp when the space was last updated.',
+    type: String,
+    format: 'date-time',
+  })
+  updatedAt!: Date;
+
+  @ApiProperty({
+    description:
+      'Logo metadata for the space. Null when a logo has not been uploaded yet.',
+    type: () => SpaceLogoResponseDto,
+    nullable: true,
+  })
+  logo: SpaceLogoResponseDto | null = null;
+}

--- a/src/space/dto/update-space-logo.dto.ts
+++ b/src/space/dto/update-space-logo.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UpdateSpaceLogoDto {
+  @ApiProperty({
+    type: 'string',
+    format: 'binary',
+    description:
+      'Image file (PNG, JPEG, SVG, etc.) representing the space logo.',
+  })
+  file!: string;
+}

--- a/src/space/dto/update-space.dto.ts
+++ b/src/space/dto/update-space.dto.ts
@@ -1,0 +1,29 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, Matches, MaxLength } from 'class-validator';
+import { SPACE_SLUG_REGEX } from './create-space.dto';
+
+export class UpdateSpaceDto {
+  @ApiPropertyOptional({
+    description: 'Updated display name for the space.',
+    example: 'Design Systems Guild',
+    maxLength: 255,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  name?: string;
+
+  @ApiPropertyOptional({
+    description: 'Updated slug used in URLs. Must remain unique across spaces.',
+    example: 'design-systems-guild',
+    maxLength: 255,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  @Matches(SPACE_SLUG_REGEX, {
+    message:
+      'Slug may only include alphanumeric characters and single hyphens separating segments.',
+  })
+  slug?: string;
+}

--- a/src/space/guards/space-owner.guard.ts
+++ b/src/space/guards/space-owner.guard.ts
@@ -1,0 +1,51 @@
+import {
+  BadRequestException,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { SpaceService } from '../space.service';
+
+interface RequestWithUser extends Request {
+  user?: {
+    userId: string;
+  };
+}
+
+@Injectable()
+export class SpaceOwnerGuard implements CanActivate {
+  constructor(private readonly spaceService: SpaceService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<RequestWithUser>();
+    const spaceId = request.params?.id;
+
+    if (!spaceId) {
+      throw new BadRequestException('Space identifier is required.');
+    }
+
+    const userId = request.user?.userId;
+    if (!userId) {
+      throw new UnauthorizedException(
+        'You must be authenticated to manage this space.',
+      );
+    }
+
+    const ownerId = await this.spaceService.getOwnerId(spaceId);
+    if (!ownerId) {
+      throw new NotFoundException('Space not found.');
+    }
+
+    if (ownerId !== userId) {
+      throw new ForbiddenException(
+        'You do not have permission to manage this space.',
+      );
+    }
+
+    return true;
+  }
+}

--- a/src/space/space.controller.ts
+++ b/src/space/space.controller.ts
@@ -1,0 +1,142 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  Put,
+  Req,
+  UploadedFile,
+  UseGuards,
+  UseInterceptors,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiConsumes,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Express, Request } from 'express';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CreateSpaceDto } from './dto/create-space.dto';
+import { SpaceResponseDto } from './dto/space-response.dto';
+import { UpdateSpaceDto } from './dto/update-space.dto';
+import { UpdateSpaceLogoDto } from './dto/update-space-logo.dto';
+import { SpaceOwnerGuard } from './guards/space-owner.guard';
+import { SpaceService } from './space.service';
+
+interface RequestWithUser extends Request {
+  user?: {
+    userId: string;
+  };
+}
+
+@ApiTags('spaces')
+@Controller('spaces')
+export class SpaceController {
+  constructor(private readonly spaceService: SpaceService) {}
+
+  @Post()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a new space.' })
+  @ApiResponse({
+    status: 201,
+    description: 'Space created successfully.',
+    type: SpaceResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Invalid payload.' })
+  @ApiResponse({ status: 401, description: 'Unauthorized.' })
+  async create(
+    @Body() dto: CreateSpaceDto,
+    @Req() request: RequestWithUser,
+  ): Promise<SpaceResponseDto> {
+    const ownerId = request.user?.userId;
+    if (!ownerId) {
+      throw new UnauthorizedException(
+        'Authenticated user context is required to create a space.',
+      );
+    }
+
+    return this.spaceService.create(ownerId, dto);
+  }
+
+  @Patch(':id')
+  @UseGuards(JwtAuthGuard, SpaceOwnerGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update the name or slug of an existing space.' })
+  @ApiResponse({
+    status: 200,
+    description: 'Space updated successfully.',
+    type: SpaceResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Invalid payload.' })
+  @ApiResponse({ status: 401, description: 'Unauthorized.' })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden. Only the owner can update the space.',
+  })
+  @ApiResponse({ status: 404, description: 'Space not found.' })
+  async update(
+    @Param('id') spaceId: string,
+    @Body() dto: UpdateSpaceDto,
+  ): Promise<SpaceResponseDto> {
+    return this.spaceService.update(spaceId, dto);
+  }
+
+  @Delete(':id')
+  @UseGuards(JwtAuthGuard, SpaceOwnerGuard)
+  @ApiBearerAuth()
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete a space permanently.' })
+  @ApiResponse({ status: 204, description: 'Space deleted successfully.' })
+  @ApiResponse({ status: 401, description: 'Unauthorized.' })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden. Only the owner can delete the space.',
+  })
+  @ApiResponse({ status: 404, description: 'Space not found.' })
+  async remove(@Param('id') spaceId: string): Promise<void> {
+    await this.spaceService.delete(spaceId);
+  }
+
+  @Put(':id/logo')
+  @UseGuards(JwtAuthGuard, SpaceOwnerGuard)
+  @UseInterceptors(FileInterceptor('file'))
+  @ApiBearerAuth()
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({ type: UpdateSpaceLogoDto })
+  @ApiOperation({
+    summary: 'Upload or replace the logo associated with a space.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Logo stored successfully.',
+    type: SpaceResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Logo file is missing or invalid.' })
+  @ApiResponse({ status: 401, description: 'Unauthorized.' })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden. Only the owner can manage the logo.',
+  })
+  @ApiResponse({ status: 404, description: 'Space not found.' })
+  async updateLogo(
+    @Param('id') spaceId: string,
+    @UploadedFile() file: Express.Multer.File,
+  ): Promise<SpaceResponseDto> {
+    if (!file) {
+      throw new BadRequestException('A logo file must be provided.');
+    }
+
+    return this.spaceService.updateLogo(spaceId, file);
+  }
+}

--- a/src/space/space.module.ts
+++ b/src/space/space.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { SpaceController } from './space.controller';
+import { SpaceOwnerGuard } from './guards/space-owner.guard';
+import { SpaceService } from './space.service';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [SpaceController],
+  providers: [SpaceService, SpaceOwnerGuard],
+  exports: [SpaceService],
+})
+export class SpaceModule {}

--- a/src/space/space.service.ts
+++ b/src/space/space.service.ts
@@ -1,0 +1,144 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { Space, SpaceLogo } from '@prisma/client';
+import { Express } from 'express';
+import { createHash } from 'crypto';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateSpaceDto } from './dto/create-space.dto';
+import {
+  SpaceLogoResponseDto,
+  SpaceResponseDto,
+} from './dto/space-response.dto';
+import { UpdateSpaceDto } from './dto/update-space.dto';
+
+type SpaceWithLogoMetadata = Space & {
+  logo: Pick<SpaceLogo, 'contentType' | 'hash'> | null;
+};
+
+@Injectable()
+export class SpaceService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(
+    ownerId: string,
+    dto: CreateSpaceDto,
+  ): Promise<SpaceResponseDto> {
+    const space = await this.prisma.space.create({
+      data: {
+        name: this.normalizeName(dto.name),
+        slug: this.normalizeSlug(dto.slug),
+        ownerId,
+      },
+      include: { logo: { select: { contentType: true, hash: true } } },
+    });
+
+    return this.toSpaceResponse(space);
+  }
+
+  async update(
+    spaceId: string,
+    dto: UpdateSpaceDto,
+  ): Promise<SpaceResponseDto> {
+    const data: Partial<Pick<Space, 'name' | 'slug'>> = {};
+
+    if (dto.name !== undefined) {
+      const normalizedName = this.normalizeName(dto.name);
+      if (!normalizedName) {
+        throw new BadRequestException('Space name cannot be empty.');
+      }
+      data.name = normalizedName;
+    }
+
+    if (dto.slug !== undefined) {
+      data.slug = this.normalizeSlug(dto.slug);
+    }
+
+    if (Object.keys(data).length === 0) {
+      throw new BadRequestException(
+        'At least one field must be provided to update the space.',
+      );
+    }
+
+    const space = await this.prisma.space.update({
+      where: { id: spaceId },
+      data,
+      include: { logo: { select: { contentType: true, hash: true } } },
+    });
+
+    return this.toSpaceResponse(space);
+  }
+
+  async delete(spaceId: string): Promise<void> {
+    await this.prisma.space.delete({ where: { id: spaceId } });
+  }
+
+  async updateLogo(
+    spaceId: string,
+    file: Express.Multer.File,
+  ): Promise<SpaceResponseDto> {
+    const hash = createHash('sha256').update(file.buffer).digest('hex');
+
+    await this.prisma.spaceLogo.upsert({
+      where: { spaceId },
+      create: {
+        spaceId,
+        data: file.buffer,
+        contentType: file.mimetype,
+        hash,
+      },
+      update: {
+        data: file.buffer,
+        contentType: file.mimetype,
+        hash,
+      },
+    });
+
+    const space = await this.prisma.space.findUnique({
+      where: { id: spaceId },
+      include: { logo: { select: { contentType: true, hash: true } } },
+    });
+
+    if (!space) {
+      throw new NotFoundException('Space not found.');
+    }
+
+    return this.toSpaceResponse(space);
+  }
+
+  async getOwnerId(spaceId: string): Promise<string | null> {
+    const space = await this.prisma.space.findUnique({
+      where: { id: spaceId },
+      select: { ownerId: true },
+    });
+
+    return space?.ownerId ?? null;
+  }
+
+  private toSpaceResponse(space: SpaceWithLogoMetadata): SpaceResponseDto {
+    return new SpaceResponseDto({
+      id: space.id,
+      slug: space.slug,
+      name: space.name,
+      ownerId: space.ownerId,
+      createdAt: space.createdAt,
+      updatedAt: space.updatedAt,
+      logo: space.logo
+        ? new SpaceLogoResponseDto({
+            contentType: space.logo.contentType ?? null,
+            hash: space.logo.hash ?? null,
+          })
+        : null,
+    });
+  }
+
+  private normalizeSlug(slug: string): string {
+    return slug.trim().toLowerCase();
+  }
+
+  private normalizeName(name: string): string {
+    return name.trim();
+  }
+}


### PR DESCRIPTION
## Summary
- add Space and SpaceLogo models to the Prisma schema to support space ownership and logo storage
- implement a dedicated Space module with DTOs, guards, service, and controller endpoints for create, update, delete, and logo management
- secure the endpoints with JWT authentication and owner checks while documenting them via Swagger decorators

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d6b20fe6d08329ada23b138501cf24