### PR TITLE
refactor: align file sharing with spaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@nestjs/jwt": "^11.0.0",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/swagger": "^7.4.2",
     "@prisma/client": "^6.15.0",
     "bcrypt": "^6.0.0",
     "class-transformer": "^0.5.1",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -134,12 +134,29 @@ model File {
   updatedAt     DateTime   @updatedAt
 
   Reminder Reminder[]
+  shares   FileShare[]
 
   space Space @relation(fields: [spaceId], references: [id], onDelete: Cascade, onUpdate: Cascade)
 
   @@index([spaceId, status])
   @@index([spaceId, uploadedAt])
   @@index([spaceId, openAiFileId])
+}
+
+model FileShare {
+  id         String   @id @default(uuid())
+  fileId     String   @db.Uuid
+  spaceId    String   @db.Uuid
+  shareToken String   @unique
+  expiresAt  DateTime?
+  note       String?  @db.VarChar(1024)
+  createdAt  DateTime @default(now())
+
+  file  File  @relation(fields: [fileId], references: [id], onDelete: Cascade)
+  space Space @relation(fields: [spaceId], references: [id], onDelete: Cascade)
+
+  @@index([fileId, spaceId])
+  @@index([spaceId])
 }
 
 model Conversation {

--- a/src/file/dto/create-file-share.dto.ts
+++ b/src/file/dto/create-file-share.dto.ts
@@ -1,0 +1,22 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsDateString, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class CreateFileShareDto {
+  @ApiPropertyOptional({
+    description: 'ISO 8601 timestamp indicating when the share link expires.',
+    type: String,
+    example: '2024-12-31T23:59:59.000Z',
+  })
+  @IsOptional()
+  @IsDateString()
+  expiresAt?: string;
+
+  @ApiPropertyOptional({
+    description: 'Optional note that will be shown to recipients of the share.',
+    maxLength: 1024,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(1024)
+  note?: string;
+}

--- a/src/file/dto/file-share-response.dto.ts
+++ b/src/file/dto/file-share-response.dto.ts
@@ -1,0 +1,47 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class FileShareResponseDto {
+  constructor(partial: Partial<FileShareResponseDto> = {}) {
+    Object.assign(this, partial);
+  }
+
+  @ApiProperty({ description: 'Unique identifier for the share link.' })
+  id!: string;
+
+  @ApiProperty({ description: 'Identifier of the shared file.' })
+  fileId!: string;
+
+  @ApiProperty({ description: 'Identifier of the space that owns the file.' })
+  spaceId!: string;
+
+  @ApiProperty({ description: 'Token used to access the share link.' })
+  shareToken!: string;
+
+  @ApiProperty({
+    description: 'Public URL that recipients can use to access the file.',
+  })
+  url!: string;
+
+  @ApiProperty({
+    description:
+      'Optional note provided with the share to describe its purpose for recipients.',
+    nullable: true,
+  })
+  note: string | null = null;
+
+  @ApiProperty({
+    description:
+      'Date and time when the share expires. Null means it does not expire.',
+    type: String,
+    format: 'date-time',
+    nullable: true,
+  })
+  expiresAt: Date | null = null;
+
+  @ApiProperty({
+    description: 'Date and time when the share was created.',
+    type: String,
+    format: 'date-time',
+  })
+  createdAt!: Date;
+}

--- a/src/file/dto/public-file-share-response.dto.ts
+++ b/src/file/dto/public-file-share-response.dto.ts
@@ -1,0 +1,58 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class PublicFileShareResponseDto {
+  constructor(partial: Partial<PublicFileShareResponseDto> = {}) {
+    Object.assign(this, partial);
+  }
+
+  @ApiProperty({ description: 'Unique identifier of the share.' })
+  id!: string;
+
+  @ApiProperty({ description: 'Identifier of the shared file.' })
+  fileId!: string;
+
+  @ApiProperty({ description: 'Identifier of the space that owns the file.' })
+  spaceId!: string;
+
+  @ApiProperty({
+    description: 'Token recipients must use to access the share.',
+  })
+  shareToken!: string;
+
+  @ApiProperty({ description: 'Name of the shared file.' })
+  filename!: string;
+
+  @ApiProperty({ description: 'MIME type of the shared file.' })
+  mimetype!: string;
+
+  @ApiProperty({ description: 'Size of the shared file in bytes.' })
+  size!: number;
+
+  @ApiProperty({
+    description: 'Presigned URL that can be used to download the file.',
+  })
+  url!: string;
+
+  @ApiProperty({
+    description:
+      'Optional note included with the share to explain its context to recipients.',
+    nullable: true,
+  })
+  note: string | null = null;
+
+  @ApiProperty({
+    description:
+      'Date and time when the share expires. Null means it does not expire.',
+    type: String,
+    format: 'date-time',
+    nullable: true,
+  })
+  expiresAt: Date | null = null;
+
+  @ApiProperty({
+    description: 'Date and time when the share was created.',
+    type: String,
+    format: 'date-time',
+  })
+  createdAt!: Date;
+}

--- a/src/file/dto/send-file-share-email.dto.ts
+++ b/src/file/dto/send-file-share-email.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsUUID } from 'class-validator';
+
+export class SendFileShareEmailDto {
+  @ApiProperty({ description: 'Identifier of the share to email.' })
+  @IsUUID()
+  shareId!: string;
+
+  @ApiProperty({
+    description:
+      'Email address of the recipient who should receive the share link.',
+  })
+  @IsEmail()
+  recipientEmail!: string;
+}

--- a/src/file/file-share.controller.ts
+++ b/src/file/file-share.controller.ts
@@ -1,0 +1,145 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+  Req,
+  UnauthorizedException,
+  UseFilters,
+  UseGuards,
+  Version,
+} from '@nestjs/common';
+import {
+  ApiCreatedResponse,
+  ApiNoContentResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+} from '@nestjs/swagger';
+
+import { JwtExceptionFilter } from 'src/auth/filters/jwt-exception.filter';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RequestWithUser } from 'types';
+import { FileOwnerGuard } from './guards/file-owner.guard';
+import { FileShareService } from './file-share.service';
+import { CreateFileShareDto } from './dto/create-file-share.dto';
+import { FileShareResponseDto } from './dto/file-share-response.dto';
+import { PublicFileShareResponseDto } from './dto/public-file-share-response.dto';
+import { SendFileShareEmailDto } from './dto/send-file-share-email.dto';
+
+@Controller('files')
+@UseFilters(JwtExceptionFilter)
+@UseGuards(JwtAuthGuard, FileOwnerGuard)
+@ApiTags('file-shares')
+export class FileShareController {
+  constructor(private readonly fileShareService: FileShareService) {}
+
+  private extractUserId(request: RequestWithUser): string {
+    const userId = request.user?.userId;
+
+    if (!userId) {
+      throw new UnauthorizedException('User context is required.');
+    }
+
+    return userId;
+  }
+
+  @Version('1')
+  @Post(':id/share')
+  @ApiOperation({ summary: 'Create a sharable link for a file.' })
+  @ApiParam({ name: 'id', description: 'Identifier of the file to share.' })
+  @ApiCreatedResponse({ type: FileShareResponseDto })
+  async createShare(
+    @Param('id') fileId: string,
+    @Req() request: RequestWithUser,
+    @Body() body: CreateFileShareDto,
+  ): Promise<FileShareResponseDto> {
+    const userId = this.extractUserId(request);
+    return this.fileShareService.createShare(userId, fileId, body);
+  }
+
+  @Version('1')
+  @Get(':id/shares')
+  @ApiOperation({ summary: 'List active share links for a file.' })
+  @ApiParam({
+    name: 'id',
+    description: 'Identifier of the file to list shares for.',
+  })
+  @ApiOkResponse({ type: FileShareResponseDto, isArray: true })
+  async listShares(
+    @Param('id') fileId: string,
+    @Req() request: RequestWithUser,
+  ): Promise<FileShareResponseDto[]> {
+    const userId = this.extractUserId(request);
+    return this.fileShareService.listShares(userId, fileId);
+  }
+
+  @Version('1')
+  @Delete(':id/shares/:shareId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Revoke a share link.' })
+  @ApiParam({
+    name: 'id',
+    description: 'Identifier of the file that owns the share.',
+  })
+  @ApiParam({
+    name: 'shareId',
+    description: 'Identifier of the share to revoke.',
+  })
+  @ApiNoContentResponse({ description: 'Share was revoked successfully.' })
+  async revokeShare(
+    @Param('id') fileId: string,
+    @Param('shareId') shareId: string,
+    @Req() request: RequestWithUser,
+  ): Promise<void> {
+    const userId = this.extractUserId(request);
+    await this.fileShareService.revokeShare(userId, fileId, shareId);
+  }
+
+  @Version('1')
+  @Post(':id/share/email')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Send a share link to a recipient via email.' })
+  @ApiParam({ name: 'id', description: 'Identifier of the shared file.' })
+  @ApiNoContentResponse({ description: 'Email sent successfully.' })
+  async sendShareEmail(
+    @Param('id') fileId: string,
+    @Req() request: RequestWithUser,
+    @Body() body: SendFileShareEmailDto,
+  ): Promise<void> {
+    const userId = this.extractUserId(request);
+    await this.fileShareService.sendShareEmail(
+      userId,
+      fileId,
+      body.shareId,
+      body.recipientEmail,
+    );
+  }
+}
+
+@Controller('share')
+@ApiTags('file-share-public')
+export class PublicFileShareController {
+  constructor(private readonly fileShareService: FileShareService) {}
+
+  @Version('1')
+  @Get(':shareToken')
+  @ApiOperation({
+    summary: 'Retrieve metadata and download link for a shared file.',
+  })
+  @ApiParam({
+    name: 'shareToken',
+    description: 'Token that identifies the share link.',
+  })
+  @ApiOkResponse({ type: PublicFileShareResponseDto })
+  async resolveShare(
+    @Param('shareToken') shareToken: string,
+  ): Promise<PublicFileShareResponseDto> {
+    return this.fileShareService.getShareByToken(shareToken);
+  }
+}

--- a/src/file/file-share.service.ts
+++ b/src/file/file-share.service.ts
@@ -1,0 +1,277 @@
+import { randomBytes } from 'node:crypto';
+
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+import { PrismaService } from '../prisma/prisma.service';
+import { MailService } from '../mail/mail.service';
+import { FilePresignedUrlService } from './presigned-url.service';
+import { CreateFileShareDto } from './dto/create-file-share.dto';
+import { FileShareResponseDto } from './dto/file-share-response.dto';
+import { PublicFileShareResponseDto } from './dto/public-file-share-response.dto';
+
+const INVALID_OR_EXPIRED_MESSAGE = 'Share link is invalid or has expired.';
+
+type FileShareRecord = {
+  id: string;
+  fileId: string;
+  spaceId: string;
+  shareToken: string;
+  expiresAt: Date | null;
+  note: string | null;
+  createdAt: Date;
+};
+
+type FileShareWithFile = FileShareRecord & {
+  file: {
+    id: string;
+    filename: string;
+    mimetype: string;
+    size: bigint;
+    s3Key: string;
+  };
+};
+
+@Injectable()
+export class FileShareService {
+  private readonly baseShareUrl: string;
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly presignedUrls: FilePresignedUrlService,
+    private readonly mailService: MailService,
+    configService: ConfigService,
+  ) {
+    const configuredBaseUrl =
+      configService.get<string>('FILE_SHARE_BASE_URL') ??
+      configService.get<string>('APP_BASE_URL') ??
+      configService.get<string>('APP_URL') ??
+      configService.get<string>('FRONTEND_URL');
+
+    this.baseShareUrl = (configuredBaseUrl ?? 'https://myapp.com').replace(
+      /\/+$/,
+      '',
+    );
+  }
+
+  async createShare(
+    userId: string,
+    fileId: string,
+    dto: CreateFileShareDto,
+  ): Promise<FileShareResponseDto> {
+    const file = await this.getAuthorizedFile(fileId, userId);
+
+    const expiresAt = this.resolveExpiry(dto.expiresAt);
+    const note = this.normalizeNote(dto.note);
+    const shareToken = await this.generateUniqueToken();
+
+    const share = (await this.fileShares.create({
+      data: {
+        fileId,
+        spaceId: file.spaceId,
+        shareToken,
+        expiresAt,
+        note,
+      },
+    })) as FileShareRecord;
+
+    return this.toFileShareResponse(share);
+  }
+
+  async listShares(
+    userId: string,
+    fileId: string,
+  ): Promise<FileShareResponseDto[]> {
+    const file = await this.getAuthorizedFile(fileId, userId);
+
+    const now = new Date();
+
+    const shares = (await this.fileShares.findMany({
+      where: {
+        fileId,
+        spaceId: file.spaceId,
+        OR: [{ expiresAt: null }, { expiresAt: { gt: now } }],
+      },
+      orderBy: { createdAt: 'desc' },
+    })) as FileShareRecord[];
+
+    return shares.map((share) => this.toFileShareResponse(share));
+  }
+
+  async revokeShare(
+    userId: string,
+    fileId: string,
+    shareId: string,
+  ): Promise<void> {
+    const file = await this.getAuthorizedFile(fileId, userId);
+
+    const share = (await this.fileShares.findFirst({
+      where: { id: shareId, fileId, spaceId: file.spaceId },
+      select: { id: true },
+    })) as { id: string } | null;
+
+    if (!share) {
+      throw new NotFoundException('Share not found.');
+    }
+
+    await this.fileShares.delete({ where: { id: shareId } });
+  }
+
+  async getShareByToken(
+    shareToken: string,
+  ): Promise<PublicFileShareResponseDto> {
+    const share = (await this.fileShares.findUnique({
+      where: { shareToken },
+      include: {
+        file: {
+          select: {
+            id: true,
+            filename: true,
+            mimetype: true,
+            size: true,
+            s3Key: true,
+          },
+        },
+      },
+    })) as FileShareWithFile | null;
+
+    if (!share) {
+      throw new NotFoundException(INVALID_OR_EXPIRED_MESSAGE);
+    }
+
+    if (share.expiresAt && share.expiresAt <= new Date()) {
+      throw new NotFoundException(INVALID_OR_EXPIRED_MESSAGE);
+    }
+
+    const url = await this.presignedUrls.getDownloadUrl(share.file.s3Key);
+
+    return new PublicFileShareResponseDto({
+      id: share.id,
+      fileId: share.fileId,
+      spaceId: share.spaceId,
+      shareToken: share.shareToken,
+      filename: share.file.filename,
+      mimetype: share.file.mimetype,
+      size: Number(share.file.size),
+      url,
+      note: share.note ?? null,
+      expiresAt: share.expiresAt ?? null,
+      createdAt: share.createdAt,
+    });
+  }
+
+  async sendShareEmail(
+    userId: string,
+    fileId: string,
+    shareId: string,
+    recipientEmail: string,
+  ): Promise<void> {
+    const file = await this.getAuthorizedFile(fileId, userId);
+
+    const share = (await this.fileShares.findFirst({
+      where: { id: shareId, fileId, spaceId: file.spaceId },
+      include: {
+        file: { select: { filename: true } },
+      },
+    })) as (FileShareRecord & { file: { filename: string } }) | null;
+
+    if (!share) {
+      throw new NotFoundException('Share not found.');
+    }
+
+    if (share.expiresAt && share.expiresAt <= new Date()) {
+      throw new BadRequestException('Cannot email an expired share link.');
+    }
+
+    const url = this.buildShareUrl(share.shareToken);
+
+    await this.mailService.sendFileShareEmail(
+      recipientEmail,
+      url,
+      share.file.filename,
+      share.note ?? null,
+      share.expiresAt ?? null,
+    );
+  }
+
+  private async getAuthorizedFile(
+    fileId: string,
+    userId: string,
+  ): Promise<{ id: string; spaceId: string }> {
+    const file = await this.prisma.file.findFirst({
+      where: { id: fileId, space: { ownerId: userId } },
+      select: { id: true, spaceId: true },
+    });
+
+    if (!file) {
+      throw new NotFoundException('File not found.');
+    }
+
+    return file;
+  }
+
+  private async generateUniqueToken(): Promise<string> {
+    while (true) {
+      const token = randomBytes(24).toString('hex');
+      const existing = (await this.fileShares.findUnique({
+        where: { shareToken: token },
+        select: { id: true },
+      })) as { id: string } | null;
+
+      if (!existing) {
+        return token;
+      }
+    }
+  }
+
+  private resolveExpiry(expiresAt?: string): Date | null {
+    if (!expiresAt) {
+      return null;
+    }
+
+    const parsed = new Date(expiresAt);
+    if (Number.isNaN(parsed.getTime())) {
+      throw new BadRequestException('Invalid expiration date.');
+    }
+
+    if (parsed <= new Date()) {
+      throw new BadRequestException('Expiration must be set in the future.');
+    }
+
+    return parsed;
+  }
+
+  private normalizeNote(note?: string): string | null {
+    if (!note) {
+      return null;
+    }
+
+    const trimmed = note.trim();
+    return trimmed.length ? trimmed : null;
+  }
+
+  private toFileShareResponse(share: FileShareRecord): FileShareResponseDto {
+    return new FileShareResponseDto({
+      id: share.id,
+      fileId: share.fileId,
+      spaceId: share.spaceId,
+      shareToken: share.shareToken,
+      url: this.buildShareUrl(share.shareToken),
+      note: share.note ?? null,
+      expiresAt: share.expiresAt ?? null,
+      createdAt: share.createdAt,
+    });
+  }
+
+  private buildShareUrl(token: string): string {
+    return `${this.baseShareUrl}/share/${token}`;
+  }
+
+  private get fileShares() {
+    return (this.prisma as unknown as { fileShare: any }).fileShare;
+  }
+}

--- a/src/file/file.module.ts
+++ b/src/file/file.module.ts
@@ -3,7 +3,12 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { S3Client } from '@aws-sdk/client-s3';
 import { PrismaModule } from '../prisma/prisma.module';
 import { OpenAiModule } from '../openai/openai.module';
+import { MailModule } from '../mail/mail.module';
 import { FileController } from './file.controller';
+import {
+  FileShareController,
+  PublicFileShareController,
+} from './file-share.controller';
 import { FileService } from './file.service';
 import { FileOwnerGuard } from './guards/file-owner.guard';
 import { FileProgressService } from './file-progress.service';
@@ -11,10 +16,11 @@ import { S3FileStorageService } from './s3-file-storage.service';
 import { OpenAiVectorStoreService } from './openai-vector-store.service';
 import { S3_CLIENT_TOKEN } from './file.tokens';
 import { FilePresignedUrlService } from './presigned-url.service';
+import { FileShareService } from './file-share.service';
 
 @Module({
-  imports: [PrismaModule, ConfigModule, OpenAiModule],
-  controllers: [FileController],
+  imports: [PrismaModule, ConfigModule, OpenAiModule, MailModule],
+  controllers: [FileController, FileShareController, PublicFileShareController],
   providers: [
     FileService,
     FileOwnerGuard,
@@ -22,6 +28,7 @@ import { FilePresignedUrlService } from './presigned-url.service';
     S3FileStorageService,
     FilePresignedUrlService,
     OpenAiVectorStoreService,
+    FileShareService,
     {
       provide: S3_CLIENT_TOKEN,
       inject: [ConfigService],
@@ -35,6 +42,6 @@ import { FilePresignedUrlService } from './presigned-url.service';
       },
     },
   ],
-  exports: [FileService, FilePresignedUrlService],
+  exports: [FileService, FilePresignedUrlService, FileShareService],
 })
 export class FileModule {}

--- a/src/file/s3-file-storage.service.ts
+++ b/src/file/s3-file-storage.service.ts
@@ -11,7 +11,6 @@ import { Readable } from 'node:stream';
 import { S3_CLIENT_TOKEN } from './file.tokens';
 import { ConfigService } from '@nestjs/config';
 import { DownloadResult, UploadParams } from 'types';
-import { createHash } from 'node:crypto';
 
 @Injectable()
 export class S3FileStorageService {
@@ -118,5 +117,4 @@ export class S3FileStorageService {
       return false;
     }
   }
-
 }

--- a/src/mail/mail.service.ts
+++ b/src/mail/mail.service.ts
@@ -18,4 +18,52 @@ export class MailService {
     await this.resendService.sendEmail(email, subject, html);
     return true;
   }
+
+  async sendFileShareEmail(
+    email: string,
+    link: string,
+    filename: string,
+    note: string | null,
+    expiresAt: Date | null,
+  ): Promise<void> {
+    const subject = `A file has been shared with you`;
+    const safeFilename = this.escapeHtml(filename);
+    const safeLink = this.escapeHtml(link);
+    const parts: string[] = [
+      `<p>The file <strong>${safeFilename}</strong> has been shared with you.</p>`,
+      `<p>You can access it securely using the link below:</p>`,
+      `<p><a href="${safeLink}">${safeLink}</a></p>`,
+    ];
+
+    if (expiresAt) {
+      parts.push(
+        `<p>This link will expire on <strong>${expiresAt.toUTCString()}</strong>.</p>`,
+      );
+    }
+
+    if (note) {
+      parts.push(
+        `<p><strong>Note from the sender:</strong><br/>${this.formatNote(note)}</p>`,
+      );
+    }
+
+    parts.push(
+      '<p>If you were not expecting this file, you can safely ignore this email.</p>',
+    );
+
+    await this.resendService.sendEmail(email, subject, parts.join(''));
+  }
+
+  private escapeHtml(input: string): string {
+    return input
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  private formatNote(note: string): string {
+    return this.escapeHtml(note).replace(/\n/g, '<br/>');
+  }
 }

--- a/test/e2e/support/fakes.ts
+++ b/test/e2e/support/fakes.ts
@@ -13,8 +13,10 @@ type VectorStoreRecord = {
 };
 
 export class FakeMailService {
-  public readonly verificationEmails: Array<{ email: string; code: string }> = [];
-  public readonly passwordResetEmails: Array<{ email: string; code: string }> = [];
+  public readonly verificationEmails: Array<{ email: string; code: string }> =
+    [];
+  public readonly passwordResetEmails: Array<{ email: string; code: string }> =
+    [];
 
   async sendVerificationEmail(email: string, code: string) {
     this.verificationEmails.push({ email, code });
@@ -102,13 +104,20 @@ export class FakeOpenAiVectorStoreService {
   async uploadFile(
     vectorStoreId: string,
     file: { buffer: Buffer; filename: string; mimetype: string },
-  ): Promise<{ fileId: string; vectorStoreFileId: string; status: 'completed' }> {
+  ): Promise<{
+    fileId: string;
+    vectorStoreFileId: string;
+    status: 'completed';
+  }> {
     const store = this.stores.get(vectorStoreId);
     if (!store) {
       throw new Error(`Unknown vector store ${vectorStoreId}`);
     }
     const fileId = `openai-file-${++this.fileCounter}`;
-    store.files.set(fileId, { buffer: file.buffer, contentType: file.mimetype });
+    store.files.set(fileId, {
+      buffer: file.buffer,
+      contentType: file.mimetype,
+    });
     return {
       fileId,
       vectorStoreFileId: `vsf-${fileId}`,
@@ -142,7 +151,9 @@ class FakeResponseStream extends EventEmitter {
   constructor(private readonly fileIds: string[]) {
     super();
     setImmediate(() => {
-      this.emit('response.output_text.delta', { delta: 'Mock assistant response.' });
+      this.emit('response.output_text.delta', {
+        delta: 'Mock assistant response.',
+      });
       setTimeout(() => {
         this.emit('response.completed');
       }, 5);

--- a/test/jest.setup.ts
+++ b/test/jest.setup.ts
@@ -34,9 +34,13 @@ if (existsSync(envPath)) {
 }
 
 process.env.JWT_SECRET = process.env.JWT_SECRET ?? 'test-secret';
-process.env.GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID ?? 'test-client-id.apps.googleusercontent.com';
-process.env.GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET ?? 'test-client-secret';
-process.env.GOOGLE_CALLBACK_URL = process.env.GOOGLE_CALLBACK_URL ?? 'http://localhost:3000/api/v1/auth/google/callback';
+process.env.GOOGLE_CLIENT_ID =
+  process.env.GOOGLE_CLIENT_ID ?? 'test-client-id.apps.googleusercontent.com';
+process.env.GOOGLE_CLIENT_SECRET =
+  process.env.GOOGLE_CLIENT_SECRET ?? 'test-client-secret';
+process.env.GOOGLE_CALLBACK_URL =
+  process.env.GOOGLE_CALLBACK_URL ??
+  'http://localhost:3000/api/v1/auth/google/callback';
 process.env.RESEND_API_KEY = process.env.RESEND_API_KEY ?? 'test-resend-key';
 process.env.AWS_S3_BUCKET = process.env.AWS_S3_BUCKET ?? 'test-bucket';
 process.env.AWS_REGION = process.env.AWS_REGION ?? 'us-east-1';

--- a/types/nestjs-swagger.d.ts
+++ b/types/nestjs-swagger.d.ts
@@ -1,0 +1,10 @@
+declare module '@nestjs/swagger' {
+  export function ApiTags(...args: unknown[]): ClassDecorator;
+  export function ApiOperation(...args: unknown[]): MethodDecorator & ClassDecorator;
+  export function ApiParam(...args: unknown[]): MethodDecorator & ClassDecorator;
+  export function ApiCreatedResponse(...args: unknown[]): MethodDecorator;
+  export function ApiOkResponse(...args: unknown[]): MethodDecorator;
+  export function ApiNoContentResponse(...args: unknown[]): MethodDecorator;
+  export function ApiProperty(...args: unknown[]): PropertyDecorator;
+  export function ApiPropertyOptional(...args: unknown[]): PropertyDecorator;
+}


### PR DESCRIPTION
## Summary
- update the Prisma FileShare model and related DTOs to store space ownership data instead of user ownership
- refactor the file share service and controller to authorize by space, include space identifiers in responses, and keep email delivery intact
- clean up lint issues, including removing an unused S3 import and formatting generated fakes

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dccf9039648329b65254fcfde27b71