### PR TITLE
feat: add space invitation workflow

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -193,6 +193,51 @@ When the delete call succeeds the record is removed from Prisma, the object is p
 
 ---
 
+# Testing Space Invitations
+
+Space invitations live under the `/v1/spaces` namespace and require manager-level membership. The examples below assume you have a valid access token for a manager/owner and know the target space ID.
+
+## Invite a Collaborator
+
+```bash
+curl -X POST http://localhost:3000/v1/spaces/<SPACE_ID>/invitations \
+  -H 'Authorization: Bearer <ACCESS_TOKEN>' \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"invitee@example.com"}'
+```
+
+The response echoes the invitation metadata (including expiry). An email will be sent via Resend containing accept/reject links.
+
+## List Invitations for a Space
+
+```bash
+curl -X GET http://localhost:3000/v1/spaces/<SPACE_ID>/invitations \
+  -H 'Authorization: Bearer <ACCESS_TOKEN>'
+```
+
+Pending invitations with an `expiresAt` in the past will be marked `EXPIRED` automatically.
+
+## Accept an Invitation
+
+After logging in as the invited user, hit the accept endpoint with the `token` query parameter from the email link:
+
+```bash
+curl -X POST "http://localhost:3000/v1/spaces/invitations/<INVITATION_ID>/accept?token=<TOKEN>" \
+  -H 'Authorization: Bearer <ACCESS_TOKEN>'
+```
+
+Acceptance provisions a `VIEWER` membership if one does not already exist.
+
+## Reject an Invitation
+
+```bash
+curl -X POST "http://localhost:3000/v1/spaces/invitations/<INVITATION_ID>/reject?token=<TOKEN>"
+```
+
+No authentication is required to reject; the token alone is sufficient to mark the invitation declined.
+
+---
+
 ## End-to-end Test Modes
 
 - Run `pnpm test:e2e` to exercise the happy-path workflow with in-memory fakes for S3 uploads, OpenAI vector stores, and streaming (fast, deterministic).

--- a/config.ts
+++ b/config.ts
@@ -14,3 +14,6 @@ export const ALLOWED_MIME_TYPES = Object.freeze(['application/pdf']);
 export const MAX_FILE_SIZE_BYTES = 25 * 1024 * 1024; // 25 MB
 export const FILE_UPLOAD_FIELD = 'files';
 export const VECTOR_STORE_NAME_PREFIX = 'superfile-space';
+
+// Space invitations
+export const SPACE_INVITATION_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days

--- a/prisma/migrations/20251002080833_init/migration.sql
+++ b/prisma/migrations/20251002080833_init/migration.sql
@@ -10,6 +10,9 @@ CREATE TYPE "public"."ConversationRole" AS ENUM ('USER', 'ASSISTANT');
 -- CreateEnum
 CREATE TYPE "public"."SpaceRole" AS ENUM ('viewer', 'editor', 'manager', 'owner');
 
+-- CreateEnum
+CREATE TYPE "public"."InvitationStatus" AS ENUM ('PENDING', 'ACCEPTED', 'REJECTED', 'EXPIRED');
+
 -- CreateTable
 CREATE TABLE "public"."User" (
     "id" TEXT NOT NULL,
@@ -72,6 +75,21 @@ CREATE TABLE "public"."SpaceMember" (
     "updatedAt" TIMESTAMP(3) NOT NULL,
 
     CONSTRAINT "SpaceMember_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."SpaceInvitation" (
+    "id" TEXT NOT NULL,
+    "spaceId" TEXT NOT NULL,
+    "email" VARCHAR(255) NOT NULL,
+    "invitedBy" TEXT NOT NULL,
+    "status" "public"."InvitationStatus" NOT NULL DEFAULT 'PENDING',
+    "tokenHash" VARCHAR(64) NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SpaceInvitation_pkey" PRIMARY KEY ("id")
 );
 
 -- CreateTable
@@ -213,6 +231,15 @@ CREATE INDEX "Space_ownerId_idx" ON "public"."Space"("ownerId");
 CREATE UNIQUE INDEX "IX_SpaceMember_spaceId_userId" ON "public"."SpaceMember"("spaceId", "userId");
 
 -- CreateIndex
+CREATE UNIQUE INDEX "SpaceInvitation_tokenHash_key" ON "public"."SpaceInvitation"("tokenHash");
+
+-- CreateIndex
+CREATE INDEX "SpaceInvitation_spaceId_status_idx" ON "public"."SpaceInvitation"("spaceId", "status");
+
+-- CreateIndex
+CREATE INDEX "SpaceInvitation_spaceId_email_idx" ON "public"."SpaceInvitation"("spaceId", "email");
+
+-- CreateIndex
 CREATE UNIQUE INDEX "SpaceLogo_spaceId_key" ON "public"."SpaceLogo"("spaceId");
 
 -- CreateIndex
@@ -265,6 +292,12 @@ ALTER TABLE "public"."SpaceMember" ADD CONSTRAINT "SpaceMember_spaceId_fkey" FOR
 
 -- AddForeignKey
 ALTER TABLE "public"."SpaceMember" ADD CONSTRAINT "SpaceMember_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."SpaceInvitation" ADD CONSTRAINT "SpaceInvitation_spaceId_fkey" FOREIGN KEY ("spaceId") REFERENCES "public"."Space"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."SpaceInvitation" ADD CONSTRAINT "SpaceInvitation_invitedBy_fkey" FOREIGN KEY ("invitedBy") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "public"."SpaceLogo" ADD CONSTRAINT "SpaceLogo_spaceId_fkey" FOREIGN KEY ("spaceId") REFERENCES "public"."Space"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,6 +36,13 @@ enum SpaceRole {
   OWNER   @map("owner")
 }
 
+enum InvitationStatus {
+  PENDING
+  ACCEPTED
+  REJECTED
+  EXPIRED
+}
+
 model User {
   id            String       @id @default(uuid())
   email         String       @unique
@@ -52,6 +59,7 @@ model User {
   sessions           Session[]
   spaces             Space[]
   spaceMemberships   SpaceMember[]
+  sentInvitations    SpaceInvitation[] @relation("SpaceInvitationsByUser")
 }
 
 model VerificationToken {
@@ -94,6 +102,7 @@ model Space {
   conversations Conversation[]
   reminders     Reminder[]
   members       SpaceMember[]
+  invitations   SpaceInvitation[]
 
   owner     User        @relation(fields: [ownerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   FileShare FileShare[]
@@ -113,6 +122,24 @@ model SpaceMember {
   user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([spaceId, userId], map: "IX_SpaceMember_spaceId_userId")
+}
+
+model SpaceInvitation {
+  id         String            @id @default(uuid())
+  spaceId    String
+  email      String            @db.VarChar(255)
+  invitedBy  String
+  status     InvitationStatus  @default(PENDING)
+  tokenHash  String            @unique @db.VarChar(64)
+  expiresAt  DateTime
+  createdAt  DateTime          @default(now())
+  updatedAt  DateTime          @updatedAt
+
+  space   Space @relation(fields: [spaceId], references: [id], onDelete: Cascade)
+  inviter User  @relation("SpaceInvitationsByUser", fields: [invitedBy], references: [id], onDelete: Cascade)
+
+  @@index([spaceId, status])
+  @@index([spaceId, email])
 }
 
 model SpaceLogo {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { FileModule } from './file/file.module';
 import { ConversationModule } from './conversation/conversation.module';
 import { ReminderModule } from './reminder/reminder.module';
 import { SpaceMemberModule } from './space-member/space-member.module';
+import { SpaceInvitationModule } from './space-invitation/space-invitation.module';
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { SpaceMemberModule } from './space-member/space-member.module';
     AuthModule,
     SpaceModule,
     SpaceMemberModule,
+    SpaceInvitationModule,
     SessionModule,
     FileModule,
     ConversationModule,

--- a/src/file/file-share.service.ts
+++ b/src/file/file-share.service.ts
@@ -214,11 +214,7 @@ export class FileShareService {
       throw new NotFoundException('File not found.');
     }
 
-    await this.spaceMembers.assertRole(
-      file.spaceId,
-      userId,
-      SpaceRole.EDITOR,
-    );
+    await this.spaceMembers.assertRole(file.spaceId, userId, SpaceRole.EDITOR);
 
     return file;
   }

--- a/src/file/file.service.ts
+++ b/src/file/file.service.ts
@@ -550,9 +550,7 @@ export class FileService {
     }
 
     if (missing.length) {
-      throw new NotFoundException(
-        `Files not found: ${missing.join(', ')}`,
-      );
+      throw new NotFoundException(`Files not found: ${missing.join(', ')}`);
     }
 
     if (forbidden.length) {

--- a/src/mail/mail.service.ts
+++ b/src/mail/mail.service.ts
@@ -54,6 +54,38 @@ export class MailService {
     await this.resendService.sendEmail(email, subject, parts.join(''));
   }
 
+  async sendSpaceInvitationEmail(options: {
+    email: string;
+    spaceName: string;
+    inviterName: string;
+    acceptUrl: string;
+    rejectUrl: string;
+    existingUser: boolean;
+    expiresAt: Date;
+  }): Promise<void> {
+    const subject = `${this.escapeHtml(options.inviterName)} invited you to join ${this.escapeHtml(options.spaceName)}`;
+
+    const acceptLink = this.escapeHtml(options.acceptUrl);
+    const rejectLink = this.escapeHtml(options.rejectUrl);
+    const spaceName = this.escapeHtml(options.spaceName);
+    const inviterName = this.escapeHtml(options.inviterName);
+    const expiresAt = options.expiresAt.toUTCString();
+
+    const intro = options.existingUser
+      ? `<p>${inviterName} invited you to join the <strong>${spaceName}</strong> space.</p>`
+      : `<p>${inviterName} invited you to join the <strong>${spaceName}</strong> space. Create an account with this email address to get started.</p>`;
+
+    const html = [
+      intro,
+      `<p><a href="${acceptLink}">Accept invitation</a></p>`,
+      `<p>If you do not want to join, you can <a href="${rejectLink}">decline the invitation</a>.</p>`,
+      `<p>This invitation will expire on <strong>${expiresAt}</strong>.</p>`,
+      '<p>If you were not expecting this invitation, you can safely ignore this email.</p>',
+    ].join('');
+
+    await this.resendService.sendEmail(options.email, subject, html);
+  }
+
   private escapeHtml(input: string): string {
     return input
       .replace(/&/g, '&amp;')

--- a/src/space-invitation/dto/create-space-invitation.dto.ts
+++ b/src/space-invitation/dto/create-space-invitation.dto.ts
@@ -1,0 +1,6 @@
+import { IsEmail } from 'class-validator';
+
+export class CreateSpaceInvitationDto {
+  @IsEmail()
+  email!: string;
+}

--- a/src/space-invitation/dto/space-invitation-response.dto.ts
+++ b/src/space-invitation/dto/space-invitation-response.dto.ts
@@ -1,0 +1,43 @@
+import { InvitationStatus } from '@prisma/client';
+
+export type SpaceInvitationInviter = {
+  id: string;
+  email: string;
+  displayName: string | null;
+};
+
+export type SpaceInvitationSpace = {
+  id: string;
+  name: string;
+};
+
+export class SpaceInvitationResponseDto {
+  readonly id: string;
+  readonly space: SpaceInvitationSpace;
+  readonly email: string;
+  readonly status: InvitationStatus;
+  readonly invitedBy: SpaceInvitationInviter;
+  readonly expiresAt: Date;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+
+  constructor(data: {
+    id: string;
+    space: SpaceInvitationSpace;
+    email: string;
+    status: InvitationStatus;
+    invitedBy: SpaceInvitationInviter;
+    expiresAt: Date;
+    createdAt: Date;
+    updatedAt: Date;
+  }) {
+    this.id = data.id;
+    this.space = data.space;
+    this.email = data.email;
+    this.status = data.status;
+    this.invitedBy = data.invitedBy;
+    this.expiresAt = data.expiresAt;
+    this.createdAt = data.createdAt;
+    this.updatedAt = data.updatedAt;
+  }
+}

--- a/src/space-invitation/space-invitation.controller.ts
+++ b/src/space-invitation/space-invitation.controller.ts
@@ -1,0 +1,89 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Query,
+  Req,
+  UnauthorizedException,
+  UseFilters,
+  UseGuards,
+  Version,
+} from '@nestjs/common';
+import { SpaceRole } from '@prisma/client';
+
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { JwtExceptionFilter } from '../auth/filters/jwt-exception.filter';
+import { RequireSpaceRole } from '../space-member/decorators/space-role.decorator';
+import { SpaceRoleGuard } from '../space-member/guards/space-role.guard';
+import { RequestWithUser } from 'types';
+import { CreateSpaceInvitationDto } from './dto/create-space-invitation.dto';
+import { SpaceInvitationResponseDto } from './dto/space-invitation-response.dto';
+import { SpaceInvitationService } from './space-invitation.service';
+
+@Controller('spaces')
+export class SpaceInvitationController {
+  constructor(private readonly spaceInvitations: SpaceInvitationService) {}
+
+  @Version('1')
+  @Post(':id/invitations')
+  @UseFilters(JwtExceptionFilter)
+  @UseGuards(JwtAuthGuard, SpaceRoleGuard)
+  @RequireSpaceRole(SpaceRole.MANAGER, { source: 'param', key: 'id' })
+  async createInvitation(
+    @Param('id') spaceId: string,
+    @Body() dto: CreateSpaceInvitationDto,
+    @Req() request: RequestWithUser,
+  ): Promise<SpaceInvitationResponseDto> {
+    const actorId = request.user?.userId;
+
+    if (!actorId) {
+      throw new UnauthorizedException(
+        'Authenticated user context is required to send invitations.',
+      );
+    }
+
+    return this.spaceInvitations.createInvitation(actorId, spaceId, dto);
+  }
+
+  @Version('1')
+  @Get(':id/invitations')
+  @UseFilters(JwtExceptionFilter)
+  @UseGuards(JwtAuthGuard, SpaceRoleGuard)
+  @RequireSpaceRole(SpaceRole.MANAGER, { source: 'param', key: 'id' })
+  async listInvitations(
+    @Param('id') spaceId: string,
+  ): Promise<SpaceInvitationResponseDto[]> {
+    return this.spaceInvitations.listInvitations(spaceId);
+  }
+
+  @Version('1')
+  @Post('invitations/:invitationId/accept')
+  @UseFilters(JwtExceptionFilter)
+  @UseGuards(JwtAuthGuard)
+  async acceptInvitation(
+    @Param('invitationId') invitationId: string,
+    @Query('token') token: string,
+    @Req() request: RequestWithUser,
+  ): Promise<SpaceInvitationResponseDto> {
+    const userId = request.user?.userId;
+
+    if (!userId) {
+      throw new UnauthorizedException(
+        'You must be authenticated to accept an invitation.',
+      );
+    }
+
+    return this.spaceInvitations.acceptInvitation(invitationId, token, userId);
+  }
+
+  @Version('1')
+  @Post('invitations/:invitationId/reject')
+  async rejectInvitation(
+    @Param('invitationId') invitationId: string,
+    @Query('token') token: string,
+  ): Promise<SpaceInvitationResponseDto> {
+    return this.spaceInvitations.rejectInvitation(invitationId, token);
+  }
+}

--- a/src/space-invitation/space-invitation.module.ts
+++ b/src/space-invitation/space-invitation.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+
+import { MailModule } from '../mail/mail.module';
+import { PrismaModule } from '../prisma/prisma.module';
+import { SpaceMemberModule } from '../space-member/space-member.module';
+import { SpaceInvitationController } from './space-invitation.controller';
+import { SpaceInvitationService } from './space-invitation.service';
+
+@Module({
+  imports: [PrismaModule, MailModule, SpaceMemberModule],
+  controllers: [SpaceInvitationController],
+  providers: [SpaceInvitationService],
+  exports: [SpaceInvitationService],
+})
+export class SpaceInvitationModule {}

--- a/src/space-invitation/space-invitation.service.ts
+++ b/src/space-invitation/space-invitation.service.ts
@@ -1,0 +1,337 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InvitationStatus, SpaceRole } from '@prisma/client';
+
+import { SPACE_INVITATION_TTL_MS } from 'config';
+import { PrismaService } from '../prisma/prisma.service';
+import { MailService } from '../mail/mail.service';
+import { CreateSpaceInvitationDto } from './dto/create-space-invitation.dto';
+import { SpaceInvitationResponseDto } from './dto/space-invitation-response.dto';
+import {
+  buildInvitationLink,
+  generateInvitationToken,
+  hashInvitationToken,
+  normalizeInvitationEmail,
+  trimTrailingSlashes,
+} from './utils/invitation-helpers';
+
+const DEFAULT_BASE_URL = 'https://myapp.com';
+
+type SpaceInvitationWithRelations = {
+  id: string;
+  spaceId: string;
+  email: string;
+  invitedBy: string;
+  status: InvitationStatus;
+  tokenHash: string;
+  expiresAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+  space: { id: string; name: string };
+  inviter: { id: string; email: string; displayName: string | null };
+};
+
+@Injectable()
+export class SpaceInvitationService {
+  private readonly baseInvitationUrl: string;
+  private readonly invitationTtlMs: number;
+
+  private readonly invitationInclude = {
+    inviter: { select: { id: true, email: true, displayName: true } },
+    space: { select: { id: true, name: true } },
+  } as const;
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly mailService: MailService,
+    configService: ConfigService,
+  ) {
+    const configuredBaseUrl =
+      configService.get<string>('SPACE_INVITATION_BASE_URL') ??
+      configService.get<string>('APP_BASE_URL') ??
+      configService.get<string>('APP_URL') ??
+      configService.get<string>('FRONTEND_URL') ??
+      DEFAULT_BASE_URL;
+
+    this.baseInvitationUrl = trimTrailingSlashes(configuredBaseUrl);
+
+    const configuredTtl = configService.get<string | number>(
+      'SPACE_INVITATION_TTL_MS',
+    );
+    const parsedTtl = Number(configuredTtl);
+    this.invitationTtlMs = Number.isFinite(parsedTtl)
+      ? parsedTtl
+      : SPACE_INVITATION_TTL_MS;
+  }
+
+  async createInvitation(
+    actorId: string,
+    spaceId: string,
+    dto: CreateSpaceInvitationDto,
+  ): Promise<SpaceInvitationResponseDto> {
+    await this.expirePendingInvitations(spaceId);
+
+    const email = normalizeInvitationEmail(dto.email);
+    const now = new Date();
+
+    const [space, inviter, existingUser, existingMember, pendingInvite] =
+      await Promise.all([
+        this.prisma.space.findUnique({
+          where: { id: spaceId },
+          select: { id: true, name: true },
+        }),
+        this.prisma.user.findUnique({
+          where: { id: actorId },
+          select: { id: true, email: true, displayName: true },
+        }),
+        this.prisma.user.findUnique({
+          where: { email },
+          select: { id: true },
+        }),
+        this.prisma.spaceMember.findFirst({
+          where: { spaceId, user: { is: { email } } },
+          select: { id: true },
+        }),
+        this.prisma.spaceInvitation.findFirst({
+          where: {
+            spaceId,
+            email,
+            status: InvitationStatus.PENDING,
+            expiresAt: { gt: now },
+          },
+          select: { id: true },
+        }),
+      ]);
+
+    if (!space) {
+      throw new NotFoundException('Space not found.');
+    }
+
+    if (!inviter) {
+      throw new NotFoundException('Inviting user not found.');
+    }
+
+    if (normalizeInvitationEmail(inviter.email) === email) {
+      throw new BadRequestException('You are already a member of this space.');
+    }
+
+    if (existingMember) {
+      throw new BadRequestException('User is already a member of this space.');
+    }
+
+    if (pendingInvite) {
+      throw new BadRequestException(
+        'An invitation is already pending for this email address.',
+      );
+    }
+
+    const rawToken = generateInvitationToken();
+    const expiresAt = new Date(Date.now() + this.invitationTtlMs);
+
+    const invitation = (await this.prisma.spaceInvitation.create({
+      data: {
+        spaceId,
+        email,
+        invitedBy: actorId,
+        tokenHash: hashInvitationToken(rawToken),
+        expiresAt,
+      },
+      include: this.invitationInclude,
+    })) as SpaceInvitationWithRelations;
+
+    const acceptUrl = buildInvitationLink(
+      this.baseInvitationUrl,
+      invitation.id,
+      'accept',
+      rawToken,
+    );
+    const rejectUrl = buildInvitationLink(
+      this.baseInvitationUrl,
+      invitation.id,
+      'reject',
+      rawToken,
+    );
+
+    await this.mailService.sendSpaceInvitationEmail({
+      email,
+      spaceName: invitation.space.name,
+      inviterName: inviter.displayName ?? inviter.email,
+      acceptUrl,
+      rejectUrl,
+      existingUser: Boolean(existingUser),
+      expiresAt,
+    });
+
+    return this.toResponse(invitation);
+  }
+
+  async listInvitations(
+    spaceId: string,
+  ): Promise<SpaceInvitationResponseDto[]> {
+    await this.expirePendingInvitations(spaceId);
+
+    const invitations = (await this.prisma.spaceInvitation.findMany({
+      where: { spaceId },
+      orderBy: { createdAt: 'desc' },
+      include: this.invitationInclude,
+    })) as SpaceInvitationWithRelations[];
+
+    return invitations.map((invitation) => this.toResponse(invitation));
+  }
+
+  async acceptInvitation(
+    invitationId: string,
+    token: string,
+    userId: string,
+  ): Promise<SpaceInvitationResponseDto> {
+    const invitation = await this.getInvitation(invitationId);
+    this.assertToken(token);
+    await this.ensurePending(invitation);
+    this.verifyToken(invitation, token);
+
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, email: true },
+    });
+
+    if (!user) {
+      throw new NotFoundException('User not found.');
+    }
+
+    if (normalizeInvitationEmail(user.email) !== invitation.email) {
+      throw new ForbiddenException(
+        'You must sign in with the email address that was invited.',
+      );
+    }
+
+    const membership = await this.prisma.spaceMember.findUnique({
+      where: {
+        spaceId_userId: {
+          spaceId: invitation.spaceId,
+          userId: user.id,
+        },
+      },
+      select: { id: true },
+    });
+
+    const updated = (await this.prisma.$transaction(async (tx) => {
+      if (!membership) {
+        await tx.spaceMember.create({
+          data: {
+            spaceId: invitation.spaceId,
+            userId: user.id,
+            role: SpaceRole.VIEWER,
+          },
+        });
+      }
+
+      return tx.spaceInvitation.update({
+        where: { id: invitation.id },
+        data: { status: InvitationStatus.ACCEPTED },
+        include: this.invitationInclude,
+      });
+    })) as SpaceInvitationWithRelations;
+
+    return this.toResponse(updated);
+  }
+
+  async rejectInvitation(
+    invitationId: string,
+    token: string,
+  ): Promise<SpaceInvitationResponseDto> {
+    const invitation = await this.getInvitation(invitationId);
+    this.assertToken(token);
+    await this.ensurePending(invitation);
+    this.verifyToken(invitation, token);
+
+    const updated = (await this.prisma.spaceInvitation.update({
+      where: { id: invitation.id },
+      data: { status: InvitationStatus.REJECTED },
+      include: this.invitationInclude,
+    })) as SpaceInvitationWithRelations;
+
+    return this.toResponse(updated);
+  }
+
+  private toResponse(
+    invitation: SpaceInvitationWithRelations,
+  ): SpaceInvitationResponseDto {
+    return new SpaceInvitationResponseDto({
+      id: invitation.id,
+      space: { id: invitation.space.id, name: invitation.space.name },
+      email: invitation.email,
+      status: invitation.status,
+      invitedBy: {
+        id: invitation.inviter.id,
+        email: invitation.inviter.email,
+        displayName: invitation.inviter.displayName,
+      },
+      expiresAt: invitation.expiresAt,
+      createdAt: invitation.createdAt,
+      updatedAt: invitation.updatedAt,
+    });
+  }
+
+  private async getInvitation(
+    invitationId: string,
+  ): Promise<SpaceInvitationWithRelations> {
+    const invitation = (await this.prisma.spaceInvitation.findUnique({
+      where: { id: invitationId },
+      include: this.invitationInclude,
+    })) as SpaceInvitationWithRelations | null;
+
+    if (!invitation) {
+      throw new NotFoundException('Invitation not found.');
+    }
+
+    return invitation;
+  }
+
+  private async ensurePending(
+    invitation: SpaceInvitationWithRelations,
+  ): Promise<void> {
+    if (invitation.status !== InvitationStatus.PENDING) {
+      throw new BadRequestException('Invitation has already been processed.');
+    }
+
+    if (invitation.expiresAt <= new Date()) {
+      await this.prisma.spaceInvitation.update({
+        where: { id: invitation.id },
+        data: { status: InvitationStatus.EXPIRED },
+      });
+      throw new BadRequestException('Invitation has expired.');
+    }
+  }
+
+  private async expirePendingInvitations(spaceId: string): Promise<void> {
+    await this.prisma.spaceInvitation.updateMany({
+      where: {
+        spaceId,
+        status: InvitationStatus.PENDING,
+        expiresAt: { lte: new Date() },
+      },
+      data: { status: InvitationStatus.EXPIRED },
+    });
+  }
+
+  private verifyToken(
+    invitation: SpaceInvitationWithRelations,
+    token: string,
+  ): void {
+    const hashed = hashInvitationToken(token);
+    if (hashed !== invitation.tokenHash) {
+      throw new ForbiddenException('Invalid invitation token.');
+    }
+  }
+
+  private assertToken(token: string): void {
+    if (!token) {
+      throw new BadRequestException('Invitation token is required.');
+    }
+  }
+}

--- a/src/space-invitation/utils/invitation-helpers.spec.ts
+++ b/src/space-invitation/utils/invitation-helpers.spec.ts
@@ -1,0 +1,45 @@
+import {
+  buildInvitationLink,
+  generateInvitationToken,
+  hashInvitationToken,
+  normalizeInvitationEmail,
+  trimTrailingSlashes,
+} from './invitation-helpers';
+
+describe('invitation helpers', () => {
+  it('normalizes emails by trimming and lowercasing', () => {
+    expect(normalizeInvitationEmail('  Example@Email.com  ')).toBe(
+      'example@email.com',
+    );
+  });
+
+  it('hashes tokens deterministically with sha256', () => {
+    const token = 'token-value';
+    expect(hashInvitationToken(token)).toBe(
+      'e6c02a5742ea9d4de588eb9b9de7bed43dc17011552186bed3e98b2c5958ff4a',
+    );
+  });
+
+  it('generates random tokens with configurable byte length', () => {
+    const token = generateInvitationToken(8);
+    expect(token).toHaveLength(16);
+    expect(generateInvitationToken(8)).not.toEqual(token);
+  });
+
+  it('strips trailing slashes from base URLs', () => {
+    expect(trimTrailingSlashes('https://example.com///')).toBe(
+      'https://example.com',
+    );
+    expect(trimTrailingSlashes('/path/only/')).toBe('/path/only');
+  });
+
+  it('builds invitation links with sanitized base URL', () => {
+    const token = 'abc 123';
+    expect(
+      buildInvitationLink('https://app.local/', 'inv-1', 'accept', token),
+    ).toBe('https://app.local/spaces/invitations/inv-1/accept?token=abc%20123');
+    expect(buildInvitationLink('', 'inv-2', 'reject', 'token')).toBe(
+      '/spaces/invitations/inv-2/reject?token=token',
+    );
+  });
+});

--- a/src/space-invitation/utils/invitation-helpers.ts
+++ b/src/space-invitation/utils/invitation-helpers.ts
@@ -1,0 +1,32 @@
+import { createHash, randomBytes } from 'node:crypto';
+
+export type InvitationAction = 'accept' | 'reject';
+
+export const normalizeInvitationEmail = (email: string): string =>
+  email.trim().toLowerCase();
+
+export const hashInvitationToken = (token: string): string =>
+  createHash('sha256').update(token).digest('hex');
+
+export const generateInvitationToken = (bytes = 32): string =>
+  randomBytes(bytes).toString('hex');
+
+export const trimTrailingSlashes = (input: string): string =>
+  input.replace(/\/+$/, '');
+
+export const buildInvitationLink = (
+  baseUrl: string,
+  invitationId: string,
+  action: InvitationAction,
+  token: string,
+): string => {
+  const sanitizedBase = trimTrailingSlashes(baseUrl || '');
+  const normalizedAction = action === 'reject' ? 'reject' : 'accept';
+  const safeToken = encodeURIComponent(token);
+
+  if (!sanitizedBase) {
+    return `/spaces/invitations/${invitationId}/${normalizedAction}?token=${safeToken}`;
+  }
+
+  return `${sanitizedBase}/spaces/invitations/${invitationId}/${normalizedAction}?token=${safeToken}`;
+};

--- a/test/e2e/app.e2e-spec.ts
+++ b/test/e2e/app.e2e-spec.ts
@@ -302,9 +302,7 @@ describe('Superfile API (e2e)', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .expect(200);
     expect(
-      membersList.body.some(
-        (member: any) => member.userId === collaborator.id,
-      ),
+      membersList.body.some((member: any) => member.userId === collaborator.id),
     ).toBe(true);
 
     const collaboratorLogin = await api

--- a/test/e2e/app.e2e-spec.ts
+++ b/test/e2e/app.e2e-spec.ts
@@ -3,7 +3,6 @@ import { Test, TestingModuleBuilder } from '@nestjs/testing';
 import * as request from 'supertest';
 import { resolve } from 'path';
 import { execSync } from 'child_process';
-import * as bcrypt from 'bcrypt';
 import { AppModule } from '../../src/app.module';
 import { PrismaService } from '../../src/prisma/prisma.service';
 import { MailService } from '../../src/mail/mail.service';
@@ -280,30 +279,84 @@ describe('Superfile API (e2e)', () => {
 
     const collaboratorEmail = `collab.user+${slugSuffix}@example.com`;
     const collaboratorPassword = 'CollabPass1!';
-    const collaboratorHash = await bcrypt.hash(collaboratorPassword, 10);
 
-    const collaborator = await prismaClient.user.create({
-      data: {
-        email: collaboratorEmail,
-        passwordHash: collaboratorHash,
-        emailVerified: true,
-      },
-    });
-
-    const addMemberRes = await api
-      .post(`/api/v1/spaces/${spaceId}/members`)
+    const invitationRes = await api
+      .post(`/api/v1/spaces/${spaceId}/invitations`)
       .set('Authorization', `Bearer ${accessToken}`)
-      .send({ userId: collaborator.id })
+      .send({ email: collaboratorEmail })
       .expect(201);
-    expect(addMemberRes.body.role).toBe('VIEWER');
+    expect(invitationRes.body.status).toBe('PENDING');
 
-    const membersList = await api
-      .get(`/api/v1/spaces/${spaceId}/members`)
+    const invitationsList = await api
+      .get(`/api/v1/spaces/${spaceId}/invitations`)
       .set('Authorization', `Bearer ${accessToken}`)
       .expect(200);
     expect(
-      membersList.body.some((member: any) => member.userId === collaborator.id),
+      invitationsList.body.some(
+        (invitation: any) => invitation.id === invitationRes.body.id,
+      ),
     ).toBe(true);
+
+    const invitationMail = mailService.spaceInvitationEmails.find(
+      (mail) => mail.email === collaboratorEmail,
+    );
+    expect(invitationMail).toBeDefined();
+
+    const acceptUrl = new URL(invitationMail!.acceptUrl);
+    const acceptPathSegments = acceptUrl.pathname.split('/').filter(Boolean);
+    const invitationIdFromUrl =
+      acceptPathSegments[acceptPathSegments.length - 2];
+    const invitationToken = acceptUrl.searchParams.get('token');
+    expect(invitationToken).toBeTruthy();
+    expect(invitationIdFromUrl).toBe(invitationRes.body.id);
+
+    const rejectedEmail = `reject.user+${slugSuffix}@example.com`;
+    const rejectedInvitationRes = await api
+      .post(`/api/v1/spaces/${spaceId}/invitations`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ email: rejectedEmail })
+      .expect(201);
+
+    const rejectedMail = mailService.spaceInvitationEmails.find(
+      (mail) => mail.email === rejectedEmail,
+    );
+    expect(rejectedMail).toBeDefined();
+    const rejectUrl = new URL(rejectedMail!.rejectUrl);
+    const rejectToken = rejectUrl.searchParams.get('token');
+    expect(rejectToken).toBeTruthy();
+
+    await api
+      .post(
+        `/api/v1/spaces/invitations/${rejectedInvitationRes.body.id}/reject`,
+      )
+      .query({ token: rejectToken })
+      .expect(201);
+
+    const invitationsAfterReject = await api
+      .get(`/api/v1/spaces/${spaceId}/invitations`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(200);
+    const rejectedInvitation = invitationsAfterReject.body.find(
+      (invitation: any) => invitation.id === rejectedInvitationRes.body.id,
+    );
+    expect(rejectedInvitation.status).toBe('REJECTED');
+
+    await api
+      .post('/api/v1/auth/signup')
+      .send({ email: collaboratorEmail, password: collaboratorPassword })
+      .expect(201);
+
+    const collaboratorVerification =
+      await prismaClient.verificationToken.findFirst({
+        where: { user: { email: collaboratorEmail } },
+        orderBy: { createdAt: 'desc' },
+      });
+    expect(collaboratorVerification).toBeTruthy();
+
+    await api
+      .post('/api/v1/auth/verify-email')
+      .send({ code: collaboratorVerification!.verificationToken })
+      .expect(201);
 
     const collaboratorLogin = await api
       .post('/api/v1/auth/login')
@@ -311,6 +364,33 @@ describe('Superfile API (e2e)', () => {
       .expect(201);
     const collaboratorAccessToken = collaboratorLogin.body
       .accessToken as string;
+
+    const acceptRes = await api
+      .post(`/api/v1/spaces/invitations/${invitationRes.body.id}/accept`)
+      .set('Authorization', `Bearer ${collaboratorAccessToken}`)
+      .query({ token: invitationToken })
+      .expect(201);
+    expect(acceptRes.body.status).toBe('ACCEPTED');
+
+    const invitationsAfterAccept = await api
+      .get(`/api/v1/spaces/${spaceId}/invitations`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(200);
+    const acceptedInvitation = invitationsAfterAccept.body.find(
+      (invitation: any) => invitation.id === invitationRes.body.id,
+    );
+    expect(acceptedInvitation.status).toBe('ACCEPTED');
+
+    const membersList = await api
+      .get(`/api/v1/spaces/${spaceId}/members`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(200);
+    const collaboratorMember = membersList.body.find(
+      (member: any) => member.user.email === collaboratorEmail,
+    );
+    expect(collaboratorMember).toBeDefined();
+    expect(collaboratorMember.role).toBe('VIEWER');
+    const collaboratorMemberId = collaboratorMember.id as string;
 
     await api
       .post('/api/v1/files')
@@ -320,13 +400,13 @@ describe('Superfile API (e2e)', () => {
       .expect(403);
 
     await api
-      .patch(`/api/v1/spaces/${spaceId}/members/${addMemberRes.body.id}`)
+      .patch(`/api/v1/spaces/${spaceId}/members/${collaboratorMemberId}`)
       .set('Authorization', `Bearer ${accessToken}`)
       .send({ role: 'EDITOR' })
       .expect(200);
 
     await api
-      .patch(`/api/v1/spaces/${spaceId}/members/${addMemberRes.body.id}`)
+      .patch(`/api/v1/spaces/${spaceId}/members/${collaboratorMemberId}`)
       .set('Authorization', `Bearer ${collaboratorAccessToken}`)
       .send({ role: 'MANAGER' })
       .expect(403);
@@ -346,7 +426,7 @@ describe('Superfile API (e2e)', () => {
       .expect(403);
 
     await api
-      .patch(`/api/v1/spaces/${spaceId}/members/${addMemberRes.body.id}`)
+      .patch(`/api/v1/spaces/${spaceId}/members/${collaboratorMemberId}`)
       .set('Authorization', `Bearer ${accessToken}`)
       .send({ role: 'MANAGER' })
       .expect(200);

--- a/test/e2e/support/fakes.ts
+++ b/test/e2e/support/fakes.ts
@@ -17,6 +17,15 @@ export class FakeMailService {
     [];
   public readonly passwordResetEmails: Array<{ email: string; code: string }> =
     [];
+  public readonly spaceInvitationEmails: Array<{
+    email: string;
+    spaceName: string;
+    inviterName: string;
+    acceptUrl: string;
+    rejectUrl: string;
+    existingUser: boolean;
+    expiresAt: Date;
+  }> = [];
 
   async sendVerificationEmail(email: string, code: string) {
     this.verificationEmails.push({ email, code });
@@ -24,6 +33,18 @@ export class FakeMailService {
 
   async sendPasswordResetEmail(email: string, code: string) {
     this.passwordResetEmails.push({ email, code });
+  }
+
+  async sendSpaceInvitationEmail(options: {
+    email: string;
+    spaceName: string;
+    inviterName: string;
+    acceptUrl: string;
+    rejectUrl: string;
+    existingUser: boolean;
+    expiresAt: Date;
+  }): Promise<void> {
+    this.spaceInvitationEmails.push(options);
   }
 }
 


### PR DESCRIPTION
## Summary
- add a SpaceInvitation model and enums to Prisma along with configuration defaults for invitation expiry
- implement a space-invitation module that issues secure tokens, emails invite links, and lets invitees accept or reject access
- document the invitation flow in README/ENDPOINTS/TESTING and extend MailService with an invitation template

## Testing
- pnpm prisma generate *(fails: Prisma engine download blocked in the sandbox)*
- pnpm build *(fails because Prisma client cannot be generated without the engines)*

------
https://chatgpt.com/codex/tasks/task_e_68de281a7b288329925f1c76f95d9cff