### PR TITLE
fix: align google oauth strategy validate signature

### DIFF
--- a/src/auth/strategies/google.strategy.ts
+++ b/src/auth/strategies/google.strategy.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
-import { Profile, Strategy, VerifyCallback } from 'passport-google-oauth20';
+import { Profile, Strategy } from 'passport-google-oauth20';
 @Injectable()
 export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
   private readonly logger = new Logger(GoogleStrategy.name);
@@ -25,9 +25,13 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
     }
   }
 
-  async validate(profile: Profile, done: VerifyCallback): Promise<void> {
+  async validate(
+    accessToken: string,
+    refreshToken: string,
+    profile: Profile,
+  ): Promise<Profile> {
     // We simply bubble the profile up to the request context so the controller
     // can pass it to AuthService where the user provisioning logic lives.
-    done(null, profile);
+    return profile;
   }
 }


### PR DESCRIPTION
## Summary
- align the Google OAuth strategy validate signature with passport-google-oauth20 expectations
- return the hydrated profile directly so the guard attaches it to the request context without invoking an undefined callback

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfa1dd154c8329a1ba99018af2a60c